### PR TITLE
`low` 品質の追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       </select>
       <label for="quality">品質</label>
       <select name="quality" id="quality">
+        <option value="low">low</option>
         <option value="normal" selected>normal</option>
         <option value="best">best</option>
       </select>

--- a/main.js
+++ b/main.js
@@ -10,10 +10,12 @@ const output_file = 'result.webm'
 const output_mime = 'video/webm'
 const quality = () => {
   switch(document.getElementById("quality").value) {
+    case 'low':
+      return []
     case 'best':
       return ['-crf', '4', '-b:v', '5000000', '-quality', 'best', '-speed', '4']
     default:
-      return []
+      return ['-crf', '4', '-b:v', '5000000']
   }
 }
 const dl_filename = () => `${input_file.replace(/\.[^.]+$/, '')}.${y_size}p.webm`

--- a/main.js
+++ b/main.js
@@ -5,6 +5,7 @@ const vender_version = '1663764183'
 GlobalWorkerOptions.workerSrc = `/v${vender_version}/pdf.worker.min.js`
 let y_size = 720
 let input_file = 'result.pdf'
+let log_text = ''
 const output_file = 'result.webm'
 const output_mime = 'video/webm'
 const quality = () => {
@@ -73,7 +74,8 @@ async function check_pdf(file_node){
     return
   }
   input_file = file.name
-  logtext.innerHTML = `[pdf] ${file.name}\n`
+  log_text = `[pdf] ${file.name}\n`
+  logtext.value = log_text
   const fileData = await readFileAsync(file)
   // PDFファイルのパース
   pdf = await getDocument({
@@ -91,7 +93,7 @@ async function check_pdf(file_node){
 
   // progress init
   progress.value = 0
-  progress.innerHTML = ''
+  progress.innerText = ''
   runBtn.removeAttribute('disabled')
 }
 
@@ -187,14 +189,16 @@ const ffmpeg = createFFmpeg({
   corePath: `/v1663896933/ffmpeg-core.js`,
 })
 ffmpeg.setLogger(({type, message}) => {
-  logtext.innerHTML += `[${type}] ${message}\n`
+  log_text += `[${type}] ${message}\n`
+  logtext.value = log_text
   logtext.scroll(0, logtext.scrollHeight);
 })
 ffmpeg.setProgress(({ratio}) => {
-  logtext.innerHTML += `[progress] ${(ratio * 100).toFixed(2)}% done\n`
+  log_text += `[progress] ${(ratio * 100).toFixed(2)}% done\n`
+  logtext.value = log_text
   logtext.scroll(0, logtext.scrollHeight);
   progress.value = ratio
-  progress.innerHTML = `${(ratio * 100).toFixed(2)}% done`
+  progress.innerText = `${(ratio * 100).toFixed(2)}% done`
 })
 const loadwait = ffmpeg.load()
 
@@ -205,7 +209,7 @@ async function run() {
   q.setAttribute('disabled', '')
   runBtn.setAttribute('disabled', '')
   // ffmpegの立ち上げ完了を待つ
-  progress.innerHTML = ''
+  progress.innerText = ''
   progress.removeAttribute('value')
   await loadwait
   const numPages = await pdfToPNGList(ffmpeg)


### PR DESCRIPTION
- `low` 品質の追加
    - 従来のエンコーディング設定を `low` に移動、 `-crf 4 -b:v 5000000` のみのエンコーディングオプションでも比較的高速高品質に出力可能なようなので、こちらを `normal` 品質 に変更
- `.innerHTML` 操作の排除
